### PR TITLE
SDK Integration

### DIFF
--- a/src/features/entry/component.js
+++ b/src/features/entry/component.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React from "react";
 import { noop } from "lodash";
 import {
   Button,
@@ -7,318 +7,320 @@ import {
   CardHeader,
   CardText,
 } from "reactstrap";
-import { KYC } from "../../config/constants";
-import SDK from '@dapis/sdk/src/compoundSDK';
-import {NavContext} from '../../context/NavContext';
-import {SDKContext, SupportedTokensContext, TokenBalanceContext,TokenNameContext} from '../../context/SDKContext';
+// import SDK from '@dapis/sdk/src/compoundSDK';
+// import {NavContext} from '../../context/NavContext';
+// import {SDKContext, SupportedTokensContext, TokenBalanceContext,TokenNameContext} from '../../context/SDKContext';
 
-const InvestLayout = ()=>{
+// const InvestLayout = ()=>{
 
-  const sdk = useContext(SDKContext);
-  const [tokenAmount, settokenAmount] = useState(0);
-  const [loader, setloader] = useState(false)
-  const [counter, setcounter] = useState(0)
-  const {tokenName, settokenName} = useContext(TokenNameContext);
-  const { route, setRoute } = useContext(NavContext);
+//   const sdk = useContext(SDKContext);
+//   const [tokenAmount, settokenAmount] = useState(0);
+//   const [loader, setloader] = useState(false)
+//   const [counter, setcounter] = useState(0)
+//   const {tokenName, settokenName} = useContext(TokenNameContext);
+//   const { route, setRoute } = useContext(NavContext);
 
-  async function handleInputChange(event) {
-    const target = event.target;
-    const value = target.type === "checkbox" ? target.checked : target.value;
-    const name = target.name;
-    if(name === "tokenName"){
-      settokenName(value);
-    }
-    else{
-      settokenAmount(value);
-    }
-  }
+//   async function handleInputChange(event) {
+//     const target = event.target;
+//     const value = target.type === "checkbox" ? target.checked : target.value;
+//     const name = target.name;
+//     if(name === "tokenName"){
+//       settokenName(value);
+//     }
+//     else{
+//       settokenAmount(value);
+//     }
+//   }
 
-  async function handleSubmitMax(){
-    const maxBalance = await sdk.getBalance(tokenName);
-    settokenAmount(maxBalance/1e18);
-  }
-
+//   async function handleSubmitMax(){
+//     const maxBalance = await sdk.getBalance(tokenName);
+//     settokenAmount(maxBalance/1e18);
+//   }
 
 
-  async function handleSubmit(){
-    setloader(true);
-     sdk.invest(tokenName,(tokenAmount*1e18).toString())
-    .on('error', function(error){ 
-      console.log("error: ")
-      console.log(error.message); })
-    .on('transactionHash', function(transactionHash){console.log("transaction hash: " +transactionHash); })
-    .on('receipt', function(receipt){
-        console.log("reciept");
-        console.log(receipt); 
-    })
-    .on('confirmation', function(confirmationNumber, receipt){ 
-      console.log("confirmed: "+ confirmationNumber);
-      console.log(receipt);
-      setcounter(counter+1);
-      if(counter===3){
-      return;}});
-  }
-  return(
-      <div>
+
+//   async function handleSubmit(){
+//     setloader(true);
+//      sdk.invest(tokenName,(tokenAmount*1e18).toString())
+//     .on('error', function(error){ 
+//       console.log("error: ")
+//       console.log(error.message); })
+//     .on('transactionHash', function(transactionHash){console.log("transaction hash: " +transactionHash); })
+//     .on('receipt', function(receipt){
+//         console.log("reciept");
+//         console.log(receipt); 
+//     })
+//     .on('confirmation', function(confirmationNumber, receipt){ 
+//       console.log("confirmed: "+ confirmationNumber);
+//       console.log(receipt);
+//       setcounter(counter+1);
+//       if(counter===3){
+//       return;}});
+//   }
+//   return(
+//       <div>
         
-        <h2>Invest Crypto</h2>
-        <img
-          src={"https://rates.titans.finance/static/images/"+tokenName+".png"}
-          height="18px"
-          style={{
-            marginBottom: "3px",
-            marginRight: "5px",
-          }}
-          alt=""
-        />
-        <br></br>
-        <h3>{tokenName}</h3>
-        <label>Amount</label>
-        <input type="text" name="tokenInvestAmount" onChange={handleInputChange} value={tokenAmount}></input>
-        <button onClick={handleSubmitMax}>Max</button>
-        <br></br>
-        <button type="button" onClick={handleSubmit}>Invest</button><br/>
-        <button onClick={() => setRoute('home')}>Cancel</button><br/>
-      </div>
-  );
-}
+//         <h2>Invest Crypto</h2>
+//         <img
+//           src={"https://rates.titans.finance/static/images/"+tokenName+".png"}
+//           height="18px"
+//           style={{
+//             marginBottom: "3px",
+//             marginRight: "5px",
+//           }}
+//           alt=""
+//         />
+//         <br></br>
+//         <h3>{tokenName}</h3>
+//         <label>Amount</label>
+//         <input type="text" name="tokenInvestAmount" onChange={handleInputChange} value={tokenAmount}></input>
+//         <button onClick={handleSubmitMax}>Max</button>
+//         <br></br>
+//         <button type="button" onClick={handleSubmit}>Invest</button><br/>
+//         <button onClick={() => setRoute('home')}>Cancel</button><br/>
+//       </div>
+//   );
+// }
 
-const WithdrawLayout = ()=>{
-  const sdk = useContext(SDKContext);
-  const [tokenAmount, settokenAmount] = useState(0);
-  const [counter, setcounter] = useState(0)
-  const {tokenName, settokenName} = useContext(TokenNameContext);
-  const { route, setRoute } = useContext(NavContext);
+// const WithdrawLayout = ()=>{
+//   const sdk = useContext(SDKContext);
+//   const [tokenAmount, settokenAmount] = useState(0);
+//   const [counter, setcounter] = useState(0)
+//   const {tokenName, settokenName} = useContext(TokenNameContext);
+//   const { route, setRoute } = useContext(NavContext);
 
-  async function handleInputChange(event) {
-    const target = event.target;
-    const value = target.type === "checkbox" ? target.checked : target.value;
-    const name = target.name;
-    if(name === "tokenName"){
-      settokenName(value);
-    }
-    else{
-      settokenAmount(value);
-    }
-  }
+//   async function handleInputChange(event) {
+//     const target = event.target;
+//     const value = target.type === "checkbox" ? target.checked : target.value;
+//     const name = target.name;
+//     if(name === "tokenName"){
+//       settokenName(value);
+//     }
+//     else{
+//       settokenAmount(value);
+//     }
+//   }
 
-  async function handleSubmit(){
-    sdk.withdraw(tokenName,(tokenAmount*1e18).toString())
-    .on('error', function(error){ 
-      console.log("error: ")
-      console.log(error.message); })
-    .on('transactionHash', function(transactionHash){ console.log("transaction hash: " +transactionHash); })
-    .on('receipt', function(receipt){
-        console.log("reciept");
-        console.log(receipt); 
-    })
-    .on('confirmation', function(confirmationNumber, receipt){ console.log("confirmed: "+ confirmationNumber);
-        console.log(receipt) });
-  }
+//   async function handleSubmit(){
+//     sdk.withdraw(tokenName,(tokenAmount*1e18).toString())
+//     .on('error', function(error){ 
+//       console.log("error: ")
+//       console.log(error.message); })
+//     .on('transactionHash', function(transactionHash){ console.log("transaction hash: " +transactionHash); })
+//     .on('receipt', function(receipt){
+//         console.log("reciept");
+//         console.log(receipt); 
+//     })
+//     .on('confirmation', function(confirmationNumber, receipt){ console.log("confirmed: "+ confirmationNumber);
+//         console.log(receipt) });
+//   }
 
-  async function handleSubmitMax(){
-    const maxBalance = await sdk.getInvestBalance(tokenName);
-    settokenAmount(maxBalance/1e18);
-  }
+//   async function handleSubmitMax(){
+//     const maxBalance = await sdk.getInvestBalance(tokenName);
+//     settokenAmount(maxBalance/1e18);
+//   }
 
-  return(
-    <div>
-      <h2>Withdraw Crypto</h2>
-      <img
-        src={"https://rates.titans.finance/static/images/"+tokenName+".png"}
-        height="18px"
-        style={{
-          marginBottom: "3px",
-          marginRight: "5px",
-        }}
-        alt=""
-      />
-      <br></br>
-      <h3>{tokenName}</h3>
-      <label>Amount</label>
-      <input type="text" name="tokenInvestAmount" onChange={handleInputChange} value={tokenAmount}></input>
-      <button onClick={handleSubmitMax}>Max</button>
-      <br></br>
-      <button type="button" onClick={handleSubmit}>Withdraw</button><br/>
-      <button onClick={() => setRoute('home')}>Cancel</button><br/>
-    </div>
+//   return(
+//     <div>
+//       <h2>Withdraw Crypto</h2>
+//       <img
+//         src={"https://rates.titans.finance/static/images/"+tokenName+".png"}
+//         height="18px"
+//         style={{
+//           marginBottom: "3px",
+//           marginRight: "5px",
+//         }}
+//         alt=""
+//       />
+//       <br></br>
+//       <h3>{tokenName}</h3>
+//       <label>Amount</label>
+//       <input type="text" name="tokenInvestAmount" onChange={handleInputChange} value={tokenAmount}></input>
+//       <button onClick={handleSubmitMax}>Max</button>
+//       <br></br>
+//       <button type="button" onClick={handleSubmit}>Withdraw</button><br/>
+//       <button onClick={() => setRoute('home')}>Cancel</button><br/>
+//     </div>
     
-  );
-}
+//   );
+// }
 
-const HomeLayout = ()=>{
-  const supportedTokens = useContext(SupportedTokensContext);
-  const tokenBalance = useContext(TokenBalanceContext);
-  const { tokenName, settokenName } = useContext(TokenNameContext);
-  const nav = useContext(NavContext);
-  const { route, setRoute } = useContext(NavContext);
-  const sdk = useContext(SDKContext);
+// const HomeLayout = ()=>{
+//   const supportedTokens = useContext(SupportedTokensContext);
+//   const tokenBalance = useContext(TokenBalanceContext);
+//   const { tokenName, settokenName } = useContext(TokenNameContext);
+//   const nav = useContext(NavContext);
+//   const { route, setRoute } = useContext(NavContext);
+//   const sdk = useContext(SDKContext);
 
-  return(
-    <>
-    {/****** My Wallet ******/}
-    <CardText
-    style={{
-      fontWeight: "bold",
-      marginTop: "-10px",
-      marginBottom: "5px",
-    }}
-  >
-    My Wallet
-  </CardText>
+//   return(
+//     <>
+//     {/****** My Wallet ******/}
+//     <CardText
+//     style={{
+//       fontWeight: "bold",
+//       marginTop: "-10px",
+//       marginBottom: "5px",
+//     }}
+//   >
+//     My Wallet
+//   </CardText>
   
-  {supportedTokens.map((token) => {
+//   {supportedTokens.map((token) => {
 
-    let Bal = tokenBalance.find((object) => {return object.name === token.name});
-      if(Bal!==undefined){
-        if(Bal.balance!=="0")
-        {
-          return(
-            <Card
-            style={{
-              marginLeft: -15,
-              marginRight: -15,
-              padding: "5px 15px",
-            }}
-            >
-              <CardText
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  fontSize: "14px",
-                }}
-              >
-                <div>
-                  <img
-                    src={"https://rates.titans.finance/static/images/"+token.name+".png"}
-                    height="18px"
-                    style={{
-                      marginBottom: "3px",
-                      marginRight: "5px",
-                    }}
-                    alt=""
-                  />
-                  {token.name}
-                </div>
-                <div><b>{Bal.balance/ 1e18}</b></div>
-              </CardText>
-            </Card>
-          )
-        }
-      }
-      return (<></>)
-    })}
+//     let Bal = tokenBalance.find((object) => {return object.name === token.name});
+//       if(Bal!==undefined){
+//         if(Bal.balance!=="0")
+//         {
+//           return(
+//             <Card
+//             style={{
+//               marginLeft: -15,
+//               marginRight: -15,
+//               padding: "5px 15px",
+//             }}
+//             >
+//               <CardText
+//                 style={{
+//                   display: "flex",
+//                   justifyContent: "space-between",
+//                   fontSize: "14px",
+//                 }}
+//               >
+//                 <div>
+//                   <img
+//                     src={"https://rates.titans.finance/static/images/"+token.name+".png"}
+//                     height="18px"
+//                     style={{
+//                       marginBottom: "3px",
+//                       marginRight: "5px",
+//                     }}
+//                     alt=""
+//                   />
+//                   {token.name}
+//                 </div>
+//                 <div><b>{Bal.balance/ 1e18}</b></div>
+//               </CardText>
+//             </Card>
+//           )
+//         }
+//       }
+//       return (<></>)
+//     })}
   
 
-  {/****** My Savings ******/}
-  <CardText
-    style={{
-      fontWeight: "bold",
-      marginTop: "15px",
-      marginBottom: "5px",
-    }}
-  >
-    Savings
-  </CardText>
+//   {/****** My Savings ******/}
+//   <CardText
+//     style={{
+//       fontWeight: "bold",
+//       marginTop: "15px",
+//       marginBottom: "5px",
+//     }}
+//   >
+//     Savings
+//   </CardText>
 
   
-  {
-    supportedTokens.map( async (token) => 
-      {
-        let apy = await sdk.getAPY(token.name);
-        console.log("APY for " + token.name+" is"+ apy);
-        return(
-          <Card
-            style={{
-              marginLeft: -15,
-              marginRight: -15,
-              padding: "5px 15px",
-            }}
-          >
-            <CardText
-              style={{
-                display: "flex",
-                justifyItems: "center",
-                justifyContent: "space-between",
-                fontSize: "14px",
-              }}
-            >
-              <div>
-                <img
-                  src={"https://rates.titans.finance/static/images/"+token.name+".png"}
-                  height="18px"
-                  style={{
-                    marginBottom: "3px",
-                    marginRight: "5px",
-                  }}
-                  alt=""
-                />
-                {token.name}
-                <span
-                  style={{
-                    marginLeft: "5px",
-                    background: "#e0e0e0",
-                    fontSize: "10px",
-                    padding: "2px 5px",
-                  }}
-                >
-                  APY: {apy}%
-                </span>
-              </div>
-              <div>
-                <b>100.14</b>
-                {" "}
-                <span
-                  style={{
-                    fontSize: "12px",
-                    color: "#23A632",
-                  }}
-                >
-                  +2.13
-                </span>
-              </div>
-            </CardText>
-            <CardText
-              style={{
-                marginTop: -15,
-                display: "flex",
-                justifyContent: "flex-end",
-              }}
-            >
-              <div
-                style={{
-                  marginRight: "10px",
-                  background: "#e0e0e0",
-                  fontSize: "12px",
-                  padding: "2px 5px",
-                }} onClick={ ()=> {
-                    settokenName(token.name);
-                    setRoute('invest');
-                    }
-                  }
-              >
-                Buy
-              </div>
-              <div
-                style={{
-                  background: "#e0e0e0",
-                  fontSize: "12px",
-                  padding: "2px 5px",
-                }} onClick={ ()=> setRoute('withdraw')}
-              >
-                Sell
-              </div>
-            </CardText>
-          </Card>
-          )
-          }
-          )
-        } 
-        </>
-  );
-}
+//   {
+//     supportedTokens.map( async (token) => 
+//       {
+//         let apy = await sdk.getAPY(token.name);
+//         console.log("APY for " + token.name+" is"+ apy);
+//         return(
+//           <Card
+//             style={{
+//               marginLeft: -15,
+//               marginRight: -15,
+//               padding: "5px 15px",
+//             }}
+//           >
+//             <CardText
+//               style={{
+//                 display: "flex",
+//                 justifyItems: "center",
+//                 justifyContent: "space-between",
+//                 fontSize: "14px",
+//               }}
+//             >
+//               <div>
+//                 <img
+//                   src={"https://rates.titans.finance/static/images/"+token.name+".png"}
+//                   height="18px"
+//                   style={{
+//                     marginBottom: "3px",
+//                     marginRight: "5px",
+//                   }}
+//                   alt=""
+//                 />
+//                 {token.name}
+//                 <span
+//                   style={{
+//                     marginLeft: "5px",
+//                     background: "#e0e0e0",
+//                     fontSize: "10px",
+//                     padding: "2px 5px",
+//                   }}
+//                 >
+//                   APY: {apy}%
+//                 </span>
+//               </div>
+//               <div>
+//                 <b>100.14</b>
+//                 {" "}
+//                 <span
+//                   style={{
+//                     fontSize: "12px",
+//                     color: "#23A632",
+//                   }}
+//                 >
+//                   +2.13
+//                 </span>
+//               </div>
+//             </CardText>
+//             <CardText
+//               style={{
+//                 marginTop: -15,
+//                 display: "flex",
+//                 justifyContent: "flex-end",
+//               }}
+//             >
+//               <div
+//                 style={{
+//                   marginRight: "10px",
+//                   background: "#e0e0e0",
+//                   fontSize: "12px",
+//                   padding: "2px 5px",
+//                 }} onClick={ ()=> {
+//                     settokenName(token.name);
+//                     setRoute('invest');
+//                     }
+//                   }
+//               >
+//                 Buy
+//               </div>
+//               <div
+//                 style={{
+//                   background: "#e0e0e0",
+//                   fontSize: "12px",
+//                   padding: "2px 5px",
+//                 }} onClick={ ()=> setRoute('withdraw')}
+//               >
+//                 Sell
+//               </div>
+//             </CardText>
+//           </Card>
+//           )
+//           }
+//           )
+//         } 
+//         </>
+//   );
+// }
 
-const ConnectWallet = ({ handleClick = noop, buttonLabel }) => {
+const ConnectWallet = ({
+  handleClick = noop,
+  buttonLabel,
+}) => {
   return (
     <Button
       onClick={handleClick}
@@ -336,116 +338,316 @@ const ConnectWallet = ({ handleClick = noop, buttonLabel }) => {
   );
 };
 
-
-const Savings = ({ onClick = noop }) => {
-  
-
-  var [sdk, setsdk] = useState(new SDK());
-  const [supportedTokens, setsupportedTokens] = useState([]);
-  const [tokenBalance, settokenBalance] = useState([]);
-  const [route, setRoute] = useState('home');
-  const [tokenName, settokenName] = useState('ETH');
-
-  async function fetchSDK() {
-    try {
-      var market = await sdk.init();
-      market = sdk.getSupportedTokens();
-      setsupportedTokens(market);
-      market.map(async (object) => {
-        const maxBalance = await sdk.getBalance(object.name);
-        const name = object.name;
-        settokenBalance(tokenBalance => [...tokenBalance, {name:object.name, balance:maxBalance}] );
-      });
-      const ethBalance = await sdk.getBalance("ETH");
-      settokenBalance(tokenBalance => [...tokenBalance, {name:"ETH", balance:ethBalance}]);
-      setsupportedTokens(supportedTokens => [...supportedTokens, {name:"ETH"}]);
-    } catch (error) {
-      // Catch any errors for any of the above operations.
-      alert(
-        `Failed to load web3, accounts, or contract. Check console for details.`,
+const MyWalletRows = ({
+  tokens = [],
+  balances = {},
+}) => {
+  const Rows = tokens.map(token => {
+    const { name } = token;
+    const balance = balances[name];
+    if (balance > 0) {
+      return (
+        <Card
+          style={{
+            marginLeft: -15,
+            marginRight: -15,
+            padding: "5px 15px",
+          }}
+          key={name}
+        >
+          <CardText
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              fontSize: "14px",
+            }}
+          >
+            <div>
+              <img
+                src={`https://rates.titans.finance/static/images/${name}.png`}
+                height="18px"
+                style={{
+                  marginBottom: "3px",
+                  marginRight: "5px",
+                }}
+                alt=""
+              />
+              {name}
+            </div>
+            <div><b>{balance}</b></div>
+          </CardText>
+        </Card>
       );
-      console.error(error);
     }
-  }
-  
-  useEffect(() => {
-    fetchSDK();
-  }, [fetchSDK,supportedTokens]);
-
-  
+    return null;
+  });
   return (
     <>
-    <div>
-      <SDKContext.Provider value={sdk}>
-        <SupportedTokensContext.Provider value={supportedTokens}>
-          <NavContext.Provider value={{ route, setRoute }}>
-            <TokenBalanceContext.Provider value={tokenBalance}>
-              <TokenNameContext.Provider value={{tokenName, settokenName}}>
-                <NavContext.Consumer>
-                  {({ route }) => {
-                    switch(route) {
-                      case 'invest': return <InvestLayout /> 
-                      case 'withdraw': return <WithdrawLayout/>
-                      default: return <HomeLayout /> 
-                    }
-                  }}
-                </NavContext.Consumer>
-              </TokenNameContext.Provider>
-            </TokenBalanceContext.Provider>
-          </NavContext.Provider>
-        </SupportedTokensContext.Provider>
-      </SDKContext.Provider>
-    </div>
-    
-  
-</>
-);
+      {Rows}
+    </>
+  )
 };
 
-const EntryCard = ({
-buttonLabel,
-handleClick = noop,
-wallet,
+const SavingsRows = ({
+  tokens = [],
+  APYs = {},
+  yieldBalances = {},
+  yieldsEarned = {},
 }) => {
-const [kyc, setKyc] = useState(false);
-console.log('zzz kyc:', kyc);
-const onClick = () => {
-window.open(`${KYC.url}`);
-setKyc(true);
+  // TODO: should use actual cToken balances here
+  const Rows = tokens.map(token => {
+    const { name } = token;
+    const apy = Number(APYs[name]).toFixed(1);
+    const balance = yieldBalances[name];
+    const earned = yieldsEarned[name];
+    const defaultValue = "0";
+    return(
+      <Card
+        style={{
+          marginLeft: -15,
+          marginRight: -15,
+          padding: "5px 15px",
+        }}
+        key={name}
+      >
+        <CardText
+          style={{
+            display: "flex",
+            justifyItems: "center",
+            justifyContent: "space-between",
+            fontSize: "14px",
+          }}
+        >
+          <div>
+            <img
+              src={`https://rates.titans.finance/static/images/${name}.png`}
+              height="18px"
+              style={{
+                marginBottom: "3px",
+                marginRight: "5px",
+              }}
+              alt=""
+            />
+            {name}
+            <span
+              style={{
+                marginLeft: "5px",
+                background: "#e0e0e0",
+                fontSize: "10px",
+                padding: "2px 5px",
+              }}
+            >
+              APY: {apy}%
+            </span>
+          </div>
+          <div>
+            <b>{balance || defaultValue}</b>
+            {" "}
+            <span
+              style={{
+                fontSize: "12px",
+                color: "#23A632",
+              }}
+            >
+              {earned || defaultValue}
+            </span>
+          </div>
+        </CardText>
+        <CardText
+          style={{
+            marginTop: -15,
+            display: "flex",
+            justifyContent: "flex-end",
+          }}
+        >
+          <div
+            style={{
+              marginRight: "10px",
+              background: "#e0e0e0",
+              fontSize: "12px",
+              padding: "2px 5px",
+            }}
+            onClick={noop}
+          >
+            Buy
+          </div>
+          <div
+            style={{
+              background: "#e0e0e0",
+              fontSize: "12px",
+              padding: "2px 5px",
+            }}
+            onClick={noop}
+          >
+            Sell
+          </div>
+        </CardText>
+      </Card>
+    );
+  });
+  return (
+    <>
+      {Rows}
+    </>
+  );
 };
-return (
-<Card
-  style={{
-    minWidth: "320px",
-    minHeight: "480px",
-    borderRadius: "24px",
-    filter: "drop-shadow(4px 8px 4px #ddd)",
-    background: "#fafafa"
-  }}
->
-  <CardHeader
-    style={{
-      fontSize: "18px",
-      textAlign: "center",
-      borderTopLeftRadius: "24px",
-      borderTopRightRadius: "24px",
-      background: "linear-gradient(to right, #4482D0, #0E4B98)",
-      color: "white",
-    }}
-  >
-    <b>CRYPTO SAVINGS APP</b>
-    <br />
-    <span style={{fontSize: "12px"}}><em>powered by APIS</em></span>
-  </CardHeader>
-  <CardBody>
-    {
-      wallet
-      ? <Savings onClick={onClick} />
-      : <ConnectWallet handleClick={handleClick} buttonLabel={buttonLabel} />
-    }
-  </CardBody>
-</Card>
-);  
+
+const Savings = ({
+  tokens = [],
+  balances = {},
+  APYs = {},
+  yieldBalances = {},
+  yieldsEarned = {},
+}) => {
+  return (
+    <>
+      <CardText
+        style={{
+          fontWeight: "bold",
+          marginTop: "-10px",
+          marginBottom: "5px",
+        }}
+      >
+        My Wallet
+      </CardText>
+      <MyWalletRows tokens={tokens} balances={balances} />
+
+      <CardText
+        style={{
+          fontWeight: "bold",
+          marginTop: "15px",
+          marginBottom: "5px",
+        }}
+      >
+        Savings
+      </CardText>
+      <SavingsRows
+        tokens={tokens}
+        APYs={APYs}
+        yieldBalances={yieldBalances}
+        yieldsEarned={yieldsEarned}
+      />
+    </>
+  );
+};
+
+
+// const Savings = ({
+//   onClick = noop
+// }) => {
+//   var [sdk, setsdk] = useState(new SDK());
+//   const [supportedTokens, setsupportedTokens] = useState([]);
+//   const [tokenBalance, settokenBalance] = useState([]);
+//   const [route, setRoute] = useState('home');
+//   const [tokenName, settokenName] = useState('ETH');
+
+//   const fetchSDK = async () => {
+//     try {
+//       // var market = await sdk.init();
+//       // market = sdk.getSupportedTokens();
+//       // setsupportedTokens(market);
+//       // market.map(async (object) => {
+//       //   const maxBalance = await sdk.getBalance(object.name);
+//       //   const name = object.name;
+//       //   settokenBalance(tokenBalance => [...tokenBalance, {name:object.name, balance:maxBalance}] );
+//       // });
+//       // const ethBalance = await sdk.getBalance("ETH");
+//       // settokenBalance(tokenBalance => [...tokenBalance, {name:"ETH", balance:ethBalance}]);
+//       // setsupportedTokens(supportedTokens => [...supportedTokens, {name:"ETH"}]);
+//     } catch (error) {
+//       // Catch any errors for any of the above operations.
+//       alert(
+//         `Failed to load web3, accounts, or contract. Check console for details.`,
+//       );
+//       console.error(error);
+//     }
+//   };
+  
+//   useEffect(() => {
+//     fetchSDK();
+//   }, []);
+
+  
+//   return (
+//     <>
+//     <div>
+//       <SDKContext.Provider value={sdk}>
+//         <SupportedTokensContext.Provider value={supportedTokens}>
+//           <NavContext.Provider value={{ route, setRoute }}>
+//             <TokenBalanceContext.Provider value={tokenBalance}>
+//               <TokenNameContext.Provider value={{tokenName, settokenName}}>
+//                 <NavContext.Consumer>
+//                   {({ route }) => {
+//                     switch(route) {
+//                       case 'invest': return <InvestLayout /> 
+//                       case 'withdraw': return <WithdrawLayout/>
+//                       default: return <HomeLayout /> 
+//                     }
+//                   }}
+//                 </NavContext.Consumer>
+//               </TokenNameContext.Provider>
+//             </TokenBalanceContext.Provider>
+//           </NavContext.Provider>
+//         </SupportedTokensContext.Provider>
+//       </SDKContext.Provider>
+//     </div>
+    
+  
+// </>
+// );
+// };
+
+const EntryCard = ({
+  buttonLabel,
+  handleClick = noop,
+  wallet,
+  tokens = [],
+  balances = {},
+  APYs = {},
+  yieldBalances = {},
+  yieldsEarned = {},
+}) => {
+  return (
+    <Card
+      style={{
+        minWidth: "320px",
+        minHeight: "480px",
+        borderRadius: "24px",
+        filter: "drop-shadow(4px 8px 4px #ddd)",
+        background: "#fafafa"
+      }}
+    >
+      <CardHeader
+        style={{
+          fontSize: "18px",
+          textAlign: "center",
+          borderTopLeftRadius: "24px",
+          borderTopRightRadius: "24px",
+          background: "linear-gradient(to right, #4482D0, #0E4B98)",
+          color: "white",
+        }}
+      >
+        <b>CRYPTO SAVINGS APP</b>
+        <br />
+        <span style={{fontSize: "12px"}}><em>powered by APIS</em></span>
+      </CardHeader>
+      <CardBody>
+        {
+          wallet
+          ? tokens.length > 0
+            ? <Savings
+                tokens={tokens}
+                balances={balances}
+                APYs={APYs}
+                yieldBalances={yieldBalances}
+                yieldsEarned={yieldsEarned}
+              />
+            : <div style={{ textAlign: "center" }}>Retrieving account info......</div>
+          : <ConnectWallet handleClick={handleClick} buttonLabel={buttonLabel} />
+        }
+      </CardBody>
+    </Card>
+  );
 };
 
 export default EntryCard;

--- a/src/features/entry/index.js
+++ b/src/features/entry/index.js
@@ -33,8 +33,24 @@ const Entry = ({
   console.log("zzz yieldsEarned:", yieldsEarned);
   console.log("zzz APYs:", APYs);
 
-  // Connect SDK
+
   useEffect(() => {
+    // Connect Web3
+    if (window && window.ethereum) {
+      window.ethereum.on("accountsChanged", (account) => {
+        console.log("accountsChanged: ", account);
+        setCount(count + 1);
+      });
+    }
+    if (hasEthereum && !networkId) {
+      // Network ID not retrieved yet, wait a bit then try again
+      setTimeout(() => {
+        console.log("Wait for networkId to become available...");
+        setCount(count + 1);
+      }, 1000);
+    }
+
+    // Connect SDK
     const getTokens = async () => {
       try {
         const sdk = new SDK();
@@ -71,24 +87,7 @@ const Entry = ({
       }
     };
     getTokens();
-  }, []);
 
-
-  // Connect Web3
-  useEffect(() => {
-    if (window && window.ethereum) {
-      window.ethereum.on("accountsChanged", (account) => {
-        console.log("accountsChanged: ", account);
-        setCount(count + 1);
-      });
-    }
-    if (hasEthereum && !networkId) {
-      // Network ID not retrieved yet, wait a bit then try again
-      setTimeout(() => {
-        console.log("Wait for networkId to become available...");
-        setCount(count + 1);
-      }, 1000);
-    }
   }, [count, networkId, hasEthereum, selectedAddress]);
 
   let onClick = noop;


### PR DESCRIPTION
## Changes
- Use the `container` and `component` pattern: put all logic in `container` and leave UI logic in `components`
- Moved all SDK calls to the `useEffect(()=>{}, [count, networkId, hasEthereum, selectedAddress])` so it is only called once every time network changed
- Added a loading page while retrieving tokens
- Hooked up actual data for `tokens`, `balances`, and `APYs`
- Added placeholders for `yieldsEarned` and `yieldBalances`
- Disabled the `Invest` and `Withdraw` calls for now

## Question
- Since each call will refresh the page once, is it possible to retrieve all information from one SDK call?

## Outstanding Issues
- Not sure why at the end it always pops up a Metamask transaction which leads to investing some tokens
- Need to add back the 'Invest' and 'Withdraw' calls
- Need to get the `yieldsEarned` and `yieldBalances` from SDK

## Issues fixed
- Need a hard-refresh to retrieve data when first time connecting to Metamask, this needs to be fixed
^-- this is fixed by moving the `connect SDK` to  `useEffect` listening to: `[count, networkId, hasEthereum, selectedAddress]` So if users change accounts they will always see the correct wallet balances